### PR TITLE
fix: add retry delays

### DIFF
--- a/test/coralogix.test.js
+++ b/test/coralogix.test.js
@@ -191,7 +191,7 @@ describe('Coralogix Tests', () => {
     );
   });
 
-  it('forwards error when posting throws as many times as we have delays', async () => {
+  it('forwards error when posting throws when all delays are consumed', async () => {
     nock('https://api.coralogix.com')
       .post('/api/v1/logs')
       .twice()

--- a/test/coralogix.test.js
+++ b/test/coralogix.test.js
@@ -174,11 +174,29 @@ describe('Coralogix Tests', () => {
     );
   });
 
-  it('forwards error when posting throws', async () => {
+  it('retries as many times as we have delays and stops when successful', async () => {
     nock('https://api.coralogix.com')
       .post('/api/v1/logs')
+      .replyWithError('that went wrong')
+      .post('/api/v1/logs')
+      .reply(200);
+    const logger = new CoralogixLogger('foo-id', '/services/func/v1', 'app', { retryDelays: [1] });
+    await assert.doesNotReject(
+      async () => logger.sendEntries([{
+        timestamp: Date.now(),
+        extractedFields: {
+          event: 'INFO\tmessage\n',
+        },
+      }]),
+    );
+  });
+
+  it('forwards error when posting throws as many times as we have delays', async () => {
+    nock('https://api.coralogix.com')
+      .post('/api/v1/logs')
+      .twice()
       .replyWithError('that went wrong');
-    const logger = new CoralogixLogger('foo-id', '/services/func/v1', 'app');
+    const logger = new CoralogixLogger('foo-id', '/services/func/v1', 'app', { retryDelays: [1] });
     await assert.rejects(
       async () => logger.sendEntries([{
         timestamp: Date.now(),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -267,7 +267,7 @@ describe('Index Tests', () => {
 
     nock('https://api.coralogix.com/api/v1/')
       .post('/logs')
-      .replyWithError('that went wrong');
+      .reply(403, 'that went wrong');
 
     nock('https://sqs.us-east-1.amazonaws.com')
       .post('/')


### PR DESCRIPTION
About once a day, feeding logs fails with a socket hang up. Adding some code that will retry in that case.