### PR TITLE
feat: allow filtering events sent to the feeder by log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ $ aws logs put-subscription-filter \
   --destination-arn 'arn:aws:lambda:<region>:<accountid>:function:helix-services--coralogix-feeder:v1'
 ```
 
+You can filter log events sent by level as follows:
+```
+  --filter-pattern '[timestamp=*Z, request_id="*-*", level=%WARN|ERROR%, event]'
+```
+this will invoke the feeder only for WARN and ERROR messages.
+
 If you get an error that CloudWatch is not allowed to execute your function, add the following permission:
 ```
 aws lambda add-permission \

--- a/src/extract-fields.js
+++ b/src/extract-fields.js
@@ -95,15 +95,26 @@ const MESSAGE_EXTRACTORS = [
 export function extractFields(logEvent) {
   const { extractedFields } = logEvent;
   if (extractedFields) {
-    let [level, message] = extractedFields.event.split('\t');
-    if (message === undefined) {
-      [level, message] = (['INFO', level]);
+    const { event, request_id: requestId, timestamp } = extractedFields;
+
+    let { level } = extractedFields;
+    let message;
+
+    if (level === undefined) {
+      // filter is: [timestamp=*Z, request_id="*-*", event]
+      [level, message] = event.split('\t');
+      if (message === undefined) {
+        [level, message] = (['INFO', level]);
+      }
+    } else {
+      // filter is: [timestamp=*Z, request_id="*-*", level=%WARN|ERROR%, event]
+      message = event;
     }
     return {
       level,
       message,
-      requestId: extractedFields.request_id,
-      timestamp: extractedFields.timestamp,
+      requestId,
+      timestamp,
     };
   }
   for (const { pattern, extract } of MESSAGE_EXTRACTORS) {

--- a/test/coralogix.test.js
+++ b/test/coralogix.test.js
@@ -59,6 +59,15 @@ describe('Coralogix Tests', () => {
             event: 'DEBUG\tthis should not be visible\n',
           },
         },
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            timestamp: '2024-11-21T13:12:30.462Z',
+            request_id: 'd12ddc0c-1f6b-51d7-be22-83b52c83d6da',
+            event: 'neither should this be visible\n',
+            level: 'DEBUG',
+          },
+        },
       ]),
     );
   });


### PR DESCRIPTION
This will decrease the invocations to the feeder for log messages that will anyway be discarded later.