### PR TITLE
feat: dual-destination log feeding (Coralogix + ClickHouse)

### DIFF
--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -76,12 +76,16 @@ export class ClickHouseLogger {
 
   async sendPayload(entries) {
     const query = `INSERT INTO ${this._table} FORMAT JSONEachRow`;
-    const url = `https://${this._host}:8443/?database=${encodeURIComponent(this._database)}&query=${encodeURIComponent(query)}&async_insert=1&wait_for_async_insert=0`;
+    const url = new URL(`https://${this._host}:8443/`);
+    url.searchParams.set('database', this._database);
+    url.searchParams.set('query', query);
+    url.searchParams.set('async_insert', '1');
+    url.searchParams.set('wait_for_async_insert', '0');
     const auth = Buffer.from(`${this._user}:${this._password}`).toString('base64');
 
     const body = entries.map((entry) => JSON.stringify(entry)).join('\n');
 
-    const resp = await fetchRetry(new Request(url, {
+    const resp = await fetchRetry(new Request(url.href, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',

--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable no-await-in-loop */
+
+import wrapFetch from 'fetch-retry';
+import { FetchError, Request } from '@adobe/fetch';
+import { extractFields } from './extract-fields.js';
+import { fetchContext } from './utils.js';
+import { LOG_LEVEL_MAPPING } from './constants.js';
+
+const { fetch } = fetchContext;
+
+const MOCHA_ENV = (process.env.HELIX_FETCH_FORCE_HTTP1 === 'true');
+
+const fetchRetry = wrapFetch(fetch, {
+  retryDelay: (attempt) => {
+    if (MOCHA_ENV) {
+      return 1;
+    }
+    /* c8 ignore next */
+    return (2 ** attempt * 1000);
+  },
+  retryOn: async (attempt, error, response) => {
+    const retries = MOCHA_ENV ? 1 /* c8 ignore next */ : 2;
+    if (error) {
+      if (error instanceof FetchError) {
+        return attempt < retries;
+      }
+      throw error;
+    }
+    if (!response.ok) {
+      throw new Error(`Failed to send logs to ClickHouse with status ${response.status}: ${await response.text()}`);
+    }
+    return false;
+  },
+});
+
+export class ClickHouseLogger {
+  constructor(opts) {
+    const {
+      host,
+      user,
+      password,
+      database = 'helix_logs_production',
+      table = 'lambda_logs_incoming',
+      funcName,
+      appName,
+      log = console,
+      level = 'info',
+      logStream,
+      logGroup,
+      subsystem,
+    } = opts;
+
+    this._host = host;
+    this._user = user;
+    this._password = password;
+    this._database = database;
+    this._table = table;
+    this._funcName = funcName;
+    this._appName = appName;
+    this._log = log;
+    this._severity = LOG_LEVEL_MAPPING[level.toUpperCase()] || LOG_LEVEL_MAPPING.INFO;
+    this._logStream = logStream;
+    this._logGroup = logGroup;
+    this._subsystem = subsystem || funcName.split('/')[1];
+  }
+
+  createLogEntry(logEvent) {
+    const { timestamp } = logEvent;
+
+    const fields = extractFields(logEvent);
+    if (!fields) {
+      this._log.warn(`Unable to extract fields from: ${JSON.stringify(logEvent, 0, 2)}`);
+      return null;
+    }
+    const { level, message, requestId } = fields;
+
+    return {
+      timestamp: new Date(timestamp).toISOString(),
+      level: level.toLowerCase(),
+      message: message.trimEnd(),
+      request_id: requestId || '',
+      function_name: this._funcName,
+      app_name: this._appName,
+      subsystem: this._subsystem,
+      log_stream: this._logStream || '',
+      log_group: this._logGroup || '',
+      severity: LOG_LEVEL_MAPPING[level] || LOG_LEVEL_MAPPING.INFO,
+    };
+  }
+
+  async sendPayload(entries) {
+    const query = `INSERT INTO ${this._table} FORMAT JSONEachRow`;
+    const url = `https://${this._host}:8443/?database=${encodeURIComponent(this._database)}&query=${encodeURIComponent(query)}&async_insert=1&wait_for_async_insert=0`;
+    const auth = Buffer.from(`${this._user}:${this._password}`).toString('base64');
+
+    const body = entries.map((entry) => JSON.stringify(entry)).join('\n');
+
+    const resp = await fetchRetry(new Request(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Basic ${auth}`,
+      },
+      body,
+    }));
+    return resp;
+  }
+
+  async sendEntries(logEvents) {
+    const rejected = [];
+    const logEntries = [];
+
+    for (const logEvent of logEvents) {
+      const logEntry = this.createLogEntry(logEvent);
+      if (!logEntry) {
+        rejected.push(logEvent);
+      } else if (logEntry.severity >= this._severity) {
+        // Remove severity from the entry sent to ClickHouse (not a table column)
+        const { severity: _, ...entry } = logEntry;
+        logEntries.push(entry);
+      }
+    }
+    if (logEntries.length) {
+      await this.sendPayload(logEntries);
+    }
+    return { rejected, sent: logEntries.length };
+  }
+
+  get log() {
+    return this._log;
+  }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export const LOG_LEVEL_MAPPING = {
+  ERROR: 5,
+  WARN: 4,
+  INFO: 3,
+  VERBOSE: 2,
+  DEBUG: 1,
+  TRACE: 1,
+  SILLY: 1,
+};

--- a/src/coralogix.js
+++ b/src/coralogix.js
@@ -17,6 +17,7 @@ import wrapFetch from 'fetch-retry';
 import { FetchError, Request } from '@adobe/fetch';
 import { extractFields } from './extract-fields.js';
 import { fetchContext } from './utils.js';
+import { LOG_LEVEL_MAPPING } from './constants.js';
 
 /**
  * @typedef LogEvent
@@ -36,16 +37,6 @@ import { fetchContext } from './utils.js';
  * @property {string} subsystemName subsystem
  * @property {string?} computerName computer name
  */
-
-const LOG_LEVEL_MAPPING = {
-  ERROR: 5,
-  WARN: 4,
-  INFO: 3,
-  VERBOSE: 2,
-  DEBUG: 1,
-  TRACE: 1,
-  SILLY: 1,
-};
 
 const { fetch } = fetchContext;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { context, ALPN_HTTP1_1 } from '@adobe/fetch';
+import { context, ALPN_HTTP1_1, FetchError } from '@adobe/fetch';
+import wrapFetch from 'fetch-retry';
 
 /**
  * Our global fetch context that limits the number of sockets used.
@@ -20,6 +21,39 @@ export const fetchContext = context({
   h1: { maxSockets: 512, maxTotalSockets: 768, keepAlive: true },
 });
 
-const { reset } = fetchContext;
+const { reset, fetch } = fetchContext;
 
 export const resetConnections = async () => reset();
+
+const MOCHA_ENV = (process.env.HELIX_FETCH_FORCE_HTTP1 === 'true');
+
+/**
+ * Create a fetch wrapper that retries on FetchError and throws on bad status.
+ *
+ * @param {string} label label used in error messages (e.g. "Coralogix", "ClickHouse")
+ * @returns wrapped fetch function
+ */
+export function createFetchRetry(label) {
+  return wrapFetch(fetch, {
+    retryDelay: (attempt) => {
+      if (MOCHA_ENV) {
+        return 1;
+      }
+      /* c8 ignore next */
+      return (2 ** attempt * 1000); // 1000, 2000, 4000
+    },
+    retryOn: async (attempt, error, response) => {
+      const retries = MOCHA_ENV ? 1 /* c8 ignore next */ : 2;
+      if (error) {
+        if (error instanceof FetchError) {
+          return attempt < retries;
+        }
+        throw error;
+      }
+      if (!response.ok) {
+        throw new Error(`Failed to send logs to ${label} with status ${response.status}: ${await response.text()}`);
+      }
+      return false;
+    },
+  });
+}

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { Nock } from './utils.js';
+import { ClickHouseLogger } from '../src/clickhouse.js';
+
+describe('ClickHouse Tests', () => {
+  let nock;
+  beforeEach(() => {
+    nock = new Nock();
+  });
+
+  afterEach(() => {
+    nock.done();
+  });
+
+  it('sends entries with correct JSONEachRow body format', async () => {
+    nock.clickhouse()
+      .reply((_, body) => {
+        // nock auto-parses single-line JSON; reconstruct the string
+        const raw = typeof body === 'string' ? body : JSON.stringify(body);
+        const lines = raw.trim().split('\n');
+        assert.strictEqual(lines.length, 1);
+        const entry = JSON.parse(lines[0]);
+        assert.strictEqual(entry.level, 'info');
+        assert.strictEqual(entry.message, 'hello world');
+        assert.strictEqual(entry.request_id, 'd12ddc0c-1f6b-51d7-be22-83b52c83d6da');
+        assert.strictEqual(entry.function_name, '/services/func/v1');
+        assert.strictEqual(entry.app_name, 'app');
+        assert.strictEqual(entry.subsystem, 'services');
+        assert.strictEqual(entry.log_stream, 'my-stream');
+        assert.strictEqual(entry.log_group, '/aws/lambda/services--func');
+        // timestamp should be ISO 8601
+        assert.ok(entry.timestamp.endsWith('Z'));
+        // severity should NOT be in the entry
+        assert.strictEqual(entry.severity, undefined);
+        return [200];
+      });
+
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+      logStream: 'my-stream',
+      logGroup: '/aws/lambda/services--func',
+    });
+    const date = new Date('2022-11-10T12:53:47.204Z');
+    await assert.doesNotReject(
+      async () => logger.sendEntries([
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            event: 'INFO\thello world\n',
+            request_id: 'd12ddc0c-1f6b-51d7-be22-83b52c83d6da',
+          },
+        },
+      ]),
+    );
+  });
+
+  it('uses Basic Auth header and async_insert query parameters', async () => {
+    const expectedAuth = `Basic ${Buffer.from('writer:secret').toString('base64')}`;
+    nock.clickhouse()
+      .reply(function checkReq() {
+        // Verify Basic Auth header
+        assert.strictEqual(this.req.headers.authorization, expectedAuth);
+        // Verify async_insert query params are in the URL
+        const url = new URL(this.req.path, 'https://ch.example.cloud:8443');
+        assert.strictEqual(url.searchParams.get('async_insert'), '1');
+        assert.strictEqual(url.searchParams.get('wait_for_async_insert'), '0');
+        return [200];
+      });
+
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+    });
+    await assert.doesNotReject(
+      async () => logger.sendEntries([
+        {
+          timestamp: Date.now(),
+          extractedFields: {
+            event: 'INFO\tmessage\n',
+          },
+        },
+      ]),
+    );
+  });
+
+  it('filters entries below configured log level', async () => {
+    nock.clickhouse()
+      .reply((_, body) => {
+        const raw = typeof body === 'string' ? body : JSON.stringify(body);
+        const lines = raw.trim().split('\n');
+        assert.strictEqual(lines.length, 1);
+        const entry = JSON.parse(lines[0]);
+        assert.strictEqual(entry.level, 'warn');
+        return [200];
+      });
+
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+      level: 'warn',
+    });
+    const date = new Date('2022-11-10T12:53:47.204Z');
+    await assert.doesNotReject(
+      async () => logger.sendEntries([
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            event: 'WARN\tthis should be visible\n',
+          },
+        },
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            event: 'INFO\tthis should not be visible\n',
+          },
+        },
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            event: 'DEBUG\tthis should not be visible either\n',
+          },
+        },
+      ]),
+    );
+  });
+
+  it('handles unknown log level (defaults to INFO)', async () => {
+    nock.clickhouse()
+      .reply((_, body) => {
+        const raw = typeof body === 'string' ? body : JSON.stringify(body);
+        const lines = raw.trim().split('\n');
+        assert.strictEqual(lines.length, 1);
+        const entry = JSON.parse(lines[0]);
+        assert.strictEqual(entry.level, 'info');
+        return [200];
+      });
+
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+      level: 'chatty',
+    });
+    const date = new Date('2022-11-10T12:53:47.204Z');
+    await assert.doesNotReject(
+      async () => logger.sendEntries([
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            event: 'INFO\tthis should be visible\n',
+          },
+        },
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            event: 'DEBUG\tthis should not be visible\n',
+          },
+        },
+      ]),
+    );
+  });
+
+  it('maps unknown event log level to INFO severity', async () => {
+    nock.clickhouse()
+      .reply((_, body) => {
+        const raw = typeof body === 'string' ? body : JSON.stringify(body);
+        const entry = JSON.parse(raw.trim());
+        assert.strictEqual(entry.level, 'bleep');
+        return [200];
+      });
+
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+    });
+    const date = new Date('2022-11-10T12:53:47.204Z');
+    await assert.doesNotReject(
+      async () => logger.sendEntries([
+        {
+          timestamp: date.getTime(),
+          extractedFields: {
+            event: 'BLEEP\tthis has unknown level\n',
+          },
+        },
+      ]),
+    );
+  });
+
+  it('returns rejected entries when extractFields returns null', async () => {
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+    });
+    const badEvent = {
+      timestamp: Date.now(),
+      message: 'This message has no known pattern and will be discarded\n',
+    };
+    const { rejected } = await logger.sendEntries([badEvent]);
+    assert.strictEqual(rejected.length, 1);
+    assert.deepStrictEqual(rejected[0], badEvent);
+  });
+
+  it('sends nothing when all entries filtered by level', async () => {
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+      level: 'info',
+    });
+    const date = new Date('2022-11-10T12:53:47.204Z');
+    const { sent } = await logger.sendEntries([
+      {
+        timestamp: date.getTime(),
+        extractedFields: {
+          event: 'DEBUG\tthis should not be visible\n',
+        },
+      },
+    ]);
+    assert.strictEqual(sent, 0);
+  });
+
+  it('retries on FetchError, stops on success', async () => {
+    nock.clickhouse()
+      .replyWithError('that went wrong')
+      .post(/.*/)
+      .reply(200);
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+    });
+    await assert.doesNotReject(
+      async () => logger.sendEntries([{
+        timestamp: Date.now(),
+        extractedFields: {
+          event: 'INFO\tmessage\n',
+        },
+      }]),
+    );
+  });
+
+  it('throws when all retries exhausted', async () => {
+    nock.clickhouse()
+      .twice()
+      .replyWithError('that went wrong');
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+    });
+    await assert.rejects(
+      async () => logger.sendEntries([{
+        timestamp: Date.now(),
+        extractedFields: {
+          event: 'INFO\tmessage\n',
+        },
+      }]),
+      /that went wrong/,
+    );
+  });
+
+  it('throws when posting returns an error other than FetchError', async () => {
+    nock.clickhouse()
+      .replyWithError(new TypeError('something went wrong'));
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+    });
+    await assert.rejects(
+      async () => logger.sendEntries([{
+        timestamp: Date.now(),
+        extractedFields: {
+          event: 'INFO\tmessage\n',
+        },
+      }]),
+      /TypeError: something went wrong/,
+    );
+  });
+
+  it('exposes log via getter', () => {
+    const myLog = { info: () => {} };
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+      log: myLog,
+    });
+    assert.strictEqual(logger.log, myLog);
+  });
+
+  it('throws on bad HTTP status code', async () => {
+    nock.clickhouse()
+      .reply(400, 'input malformed');
+    const logger = new ClickHouseLogger({
+      host: 'ch.example.cloud',
+      user: 'writer',
+      password: 'secret',
+      funcName: '/services/func/v1',
+      appName: 'app',
+    });
+    await assert.rejects(
+      async () => logger.sendEntries([{
+        timestamp: Date.now(),
+        extractedFields: {
+          event: 'INFO\tmessage\n',
+        },
+      }]),
+      /Failed to send logs to ClickHouse with status 400: input malformed/,
+    );
+  });
+});

--- a/test/coralogix.test.js
+++ b/test/coralogix.test.js
@@ -292,7 +292,7 @@ describe('Coralogix Tests', () => {
           event: 'INFO\tmessage\n',
         },
       }]),
-      /Failed to send logs with status 400: input malformed/,
+      /Failed to send logs to Coralogix with status 400: input malformed/,
     );
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -42,6 +42,8 @@ export function Nock() {
     return scope.post('/logs/v1/singles');
   };
 
+  nocker.clickhouse = ({ host = 'ch.example.cloud' } = {}) => nocker(`https://${host}:8443`).post(/.*/);
+
   nocker.done = () => {
     Object.values(scopes).forEach((s) => s.done());
     if (unmatched) {


### PR DESCRIPTION
## Summary

- Add `ClickHouseLogger` class mirroring `CoralogixLogger` interface, targeting ClickHouse HTTP API with Basic Auth and async inserts
- Send Lambda logs concurrently to both Coralogix and ClickHouse via `Promise.allSettled()`
- ClickHouse failures are logged but do **not** affect Coralogix flow, DLQ, or response status
- Extract shared `LOG_LEVEL_MAPPING` into `src/constants.js`
- Fully backward compatible: without `CLICKHOUSE_*` env vars, behavior is identical to today

## New Environment Variables

| Name | Required | Description |
|------|----------|-------------|
| `CLICKHOUSE_HOST` | No | ClickHouse hostname |
| `CLICKHOUSE_USER` | No | ClickHouse user with INSERT permission |
| `CLICKHOUSE_PASSWORD` | No | ClickHouse user password |
| `CLICKHOUSE_DATABASE` | No | Database (default: `helix_logs_production`) |

All three of HOST/USER/PASSWORD must be set to enable ClickHouse.

## Test plan

- [x] All 55 tests pass (was 43), 100% coverage maintained
- [x] No lint errors
- [ ] Deploy without ClickHouse env vars — verify identical behavior
- [ ] Run SQL migration against ClickHouse Cloud
- [ ] Set ClickHouse env vars on Lambda
- [ ] Query `SELECT count() FROM helix_logs_production.lambda_logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)